### PR TITLE
Fix wrong Unix Epoch date

### DIFF
--- a/resources/packages/elm-lang/core.json
+++ b/resources/packages/elm-lang/core.json
@@ -3419,7 +3419,7 @@
     },
     {
       "name": "toTime",
-      "comment": "Convert a date into a time since midnight (UTC) of 1 January 1990 (i.e.\n[UNIX time](http://en.wikipedia.org/wiki/Unix_time)). Given the date 23 June\n1990 at 11:45AM this returns the corresponding time.",
+      "comment": "Convert a date into a time since midnight (UTC) of 1 January 1970 (i.e.\n[UNIX time](http://en.wikipedia.org/wiki/Unix_time)). Given the date 23 June\n1990 at 11:45AM this returns the corresponding time.",
       "type": {
         "tag": "lambda",
         "in": {


### PR DESCRIPTION
Unix time began on 1/1/1970, not 1990.  Given the way all of the Date library examples are using dates in 1990, this seems like a clear typo.